### PR TITLE
Fix python3 shebang

### DIFF
--- a/scripts/totalopenstation-cli-connector.py
+++ b/scripts/totalopenstation-cli-connector.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 # filename: totalopenstation-cli-connector.py
 # Copyright 2008,2011 Stefano Costa <steko@iosa.it>

--- a/scripts/totalopenstation-cli-parser.py
+++ b/scripts/totalopenstation-cli-parser.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 # filename: totalopenstation-cli-parser.py
 # Copyright 2008-2013 Stefano Costa <steko@iosa.it>

--- a/scripts/totalopenstation-gui.py
+++ b/scripts/totalopenstation-gui.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 # filename: totalopenstation-gui.py
 # Copyright 2008-2019 Stefano Costa <steko@iosa.it>


### PR DESCRIPTION
`#!/usr/bin/env python` does not really exist and may refer to python2 or python3. Since the requirement is python3, ensure that python3 is used.