### PR TITLE
Add Python 3.10 to the list of CI targets

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Python 3.10 was released a few weeks ago. It's good to run our test suite with this version, too.