### PR TITLE
fix #194: align Python supported versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 dynamic = ["version", "readme"]
 name = "totalopenstation"
 dependencies = ["pyserial==3.5", "pygeoif==1.4.0"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [
     { name = "Stefano Costa" },
     { name = "Damien Gaignon" },
@@ -23,11 +23,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: GIS",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 env_list =
-    py39
     py310
     py311
     py312
     py313
+    py314
 minversion = 4.14.2
 
 [testenv]


### PR DESCRIPTION
## Summary
- Remove Python 3.9 (EOL)
- Add Python 3.14 support
- Update pyproject.toml, pytest workflow, and tox.ini

Fixes #194