### PR TITLE
fix #127: adopt ezdxf library for DXF export

### DIFF
--- a/docs/output_formats/of_implemented.rst
+++ b/docs/output_formats/of_implemented.rst
@@ -94,13 +94,27 @@ Description
 This format is a standard format for CAD softwares like AutoCAD, QCAD,
 LibreCAD...
 
+.. versionchanged:: 0.7
+
+The DXF output now uses the `ezdxf <https://ezdxf.mozman.at/>`_ library for
+robust DXF generation. Output uses the R12 format for maximum compatibility
+with CAD software.
+
 Data format
 -----------
 
-The format is based on the official `DXF R15 (2000) documentation
-<https://www.autodesk.com/techpubs/autocad/acad2000/dxf/index.htm>`_. |br|
-Layers can be separated for each point or not. |br|
-This format can describe points or lines.
+The output includes the following DXF entities:
+
+- **Point** entities for survey points
+- **Text** entities for point ID and elevation labels
+- **Polyline** entities for LineString geometries
+
+Layer organization:
+
+- When ``separate_layers`` is enabled (default), points are organized into
+  layers based on their description, with sub-layers for points, Z coordinates,
+  and labels (e.g. ``WALL_POINTS``, ``WALL_Z_COORDS``, ``WALL_LABELS``)
+- Each description group is assigned a distinct color
 
 
 ==============================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 dynamic = ["version", "readme"]
 name = "totalopenstation"
-dependencies = ["pyserial==3.5", "pygeoif==1.4.0"]
+dependencies = ["pyserial==3.5", "pygeoif==1.4.0", "ezdxf>=1.0.0"]
 requires-python = ">= 3.9"
 authors = [
     { name = "Stefano Costa" },

--- a/totalopenstation/output/tops_dxf.py
+++ b/totalopenstation/output/tops_dxf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # filename: tops_dxf.py
 # Copyright 2008-2009 Stefano Costa <steko@iosa.it>
+# Copyright 2025 Enzo Cocca <enzo.ccc@gmail.com>
 
 # This file is part of Total Open Station.
 
@@ -19,148 +20,127 @@
 # along with Total Open Station.  If not, see
 # <http://www.gnu.org/licenses/>.
 
+import io
+import ezdxf
+from ezdxf.enums import TextEntityAlignment
 
 from . import Builder
 
 
 class OutputFormat(Builder):
-
     """
-    Exports points data in AutoCAD DXF format.
+    Exports points data in AutoCAD DXF format using ezdxf library.
 
-    It is based on the official DXF2000 documentation. Works with AutoCAD
-    versions ranging at least from 2005 up to 2009, and QCAD.
+    This implementation uses ezdxf for robust DXF file generation,
+    supporting modern AutoCAD versions while maintaining compatibility.
 
-    ``data`` should be an iterable (e.g. list) containing one iterable (e.g.
-    tuple) for each point. The default order is PID, x, y, z, TEXT.
-
-    This is consistent with our current standard.
+    ``data`` should be an iterable (e.g. list) containing Feature objects.
+    Each Feature has geometry (Point or LineString) and metadata (id, desc).
     """
 
     def __init__(self, data, separate_layers=True):
-
         self.data = data
         self.separate_layers = separate_layers
         self.text_height = 0.05
 
     def process(self):
-        '''Process the input data and return a string as output.
+        """Process the input data and return a string as output.
 
         This is because we want to keep the generation of output
-        separated from saving it to disk.'''
+        separated from saving it to disk.
+        """
+        # Create a new DXF document (R12 format for maximum compatibility)
+        doc = ezdxf.new('R12')
+        doc.header['$INSUNITS'] = 0  # Unitless
+        msp = doc.modelspace()
 
-        result = ''
-
-        # header
-        result += '999\nDXF created from Total Open Station\n'
-        result += '  0\nSECTION\n'
-        result += '  2\nHEADER\n'
-        result += '  9\n$ACADVER\n'
-        result += '  1\nAC1009\n' # R11
-        result += '  0\nENDSEC\n'
-
-        # extract layer list
+        # Extract unique layer codes and assign colors
         codes = set([p.desc for p in self.data])
-        codes = [c.replace('.','_') for c in codes]
-        layers = dict(enumerate(codes))
-        colors = dict((i, j % 255) for i, j in zip(list(layers.values()), list(layers.keys())))
+        codes = [c.replace('.', '_') for c in codes]
+        colors = {code: (i % 255) + 1 for i, code in enumerate(codes)}
 
-        # layer table
-        result += '  0\nSECTION\n  2\nTABLES\n  0\nTABLE\n  2\nLAYER\n'
-        for l in codes:
-            if self.separate_layers is True:
-                result += '  0\nLAYER\n'           # start definition of LAYER
-                result += '  5\n10\n'              # LAYER handle
-                result += f'  2\n{l}_POINTS\n'    # LAYER name
-                result += ' 70\n0\n'              # LAYER is not frozen
-                result += f' 62\n{int(colors[l]) + 1}\n' # LAYER color
-                result += '  6\nCONTINUOUS\n'      # LAYER linetype
-
-                result += '  0\nLAYER\n'           # same as above
-                result += '  5\n10\n'
-                result +=  f'  2\n{l}_Z_COORDS\n'
-                result += ' 70\n0\n'
-                result += f' 62\n{int(colors[l]) + 1}\n'
-                result += '  6\nCONTINUOUS\n'
-
-                result += '  0\nLAYER\n'           # ditto
-                result += '  5\n10\n'
-                result += f'  2\n{l}_LABELS\n'
-                result += ' 70\n0\n'
-                result += f' 62\n{int(colors[l]) + 1}\n'
-                result += '  6\nCONTINUOUS\n'
+        # Create layers
+        for code in codes:
+            color = colors[code]
+            if self.separate_layers:
+                doc.layers.add(f"{code}_POINTS", color=color)
+                doc.layers.add(f"{code}_Z_COORDS", color=color)
+                doc.layers.add(f"{code}_LABELS", color=color)
             else:
-                result += '  0\nLAYER\n'           # ditto
-                result += '  5\n10\n'
-                result += f'  2\n{l}\n'          # LAYER name w/o any suffix
-                result += ' 70\n0\n'
-                result += f' 62\n{int(colors[l]) + 1}\n'
-                result += '  6\nCONTINUOUS\n'
+                doc.layers.add(code, color=color)
 
-        result += '  0\nENDTAB\n  0\nENDSEC\n'
-
-        # drawing entities
-        result += '  0\nSECTION\n  2\nENTITIES\n'
-
+        # Add entities
         for p in self.data:
-            p_layer = p.desc
+            p_layer = p.desc.replace('.', '_')
             geom = p.geometry
+
             if geom.geom_type == 'Point':
-                if self.separate_layers is True:
-                    layer_point = f"{p_layer}_POINTS"
-                    layer_z_text = f"{p_layer}_Z_COORD"
-                    layer_id_text = f"{p_layer}_LABELS"
-                else:
-                    layer_point = layer_z_text = layer_id_text = p_layer
-                p_yz = str(float(geom.y) - (self.text_height * 1.2))
-
-                # add point
-                result += '  0\nPOINT\n'
-                result += f'  8\n{layer_point}\n'
-                result += f' 10\n{geom.x}\n'
-                result += f' 20\n{geom.y}\n'
-
-                # add ID number
-                result += '  0\nTEXT\n'
-                result +=  f'  1\n{p.id}\n'
-                result +=  f'  8\n{layer_id_text}\n'
-                result +=  f' 10\n{geom.x}\n'
-                result +=  f' 20\n{geom.y}\n'
-                result += f' 40\n{self.text_height:01.2f}\n' 
-                result += ' 62\n256\n'
-
-                try:
-                    geom.z
-                except ValueError:
-                    pass
-                else:
-                    # add Z value as string
-                    result += '  0\nTEXT\n'
-                    result +=  f'  1\n{geom.z}\n'
-                    result +=  f'  8\n{layer_z_text}\n'
-                    result +=  f' 10\n{geom.x}\n'
-                    result +=  f' 20\n{p_yz}\n'
-                    result += f' 40\n{self.text_height:01.2f}\n'
-                    result += ' 62\n256\n'
-
+                self._add_point_entity(msp, p, p_layer, geom)
             elif geom.geom_type == 'LineString':
-                result += '  0\nPOLYLINE\n'
-                result +=  f'  8\n{p_layer}\n'
-                result += '  6\nCONTINUOUS\n'
-                result += ' 62\n256\n'
-                result += ' 66\n1\n'
-                result += ' 70\n0\n'
-                for v in geom.coords:
-                    result += '  0\nVERTEX\n'
-                    result +=  f'  8\n{p_layer}\n'
-                    result +=  f' 10\n{v[0]}\n' # x
-                    result +=  f' 20\n{v[1]}\n' # y
-                    try:
-                        result +=  f' 30\n{v[2]}\n' # z
-                    except IndexError:
-                        result += ' 30\n0\n'
-                result += '  0\nSEQEND\n'
+                self._add_linestring_entity(msp, p, p_layer, geom)
             else:
-                raise NotImplementedError
-        result += '  0\nENDSEC\n  0\nEOF\n'
-        return result
+                raise NotImplementedError(
+                    f"Geometry type '{geom.geom_type}' is not supported"
+                )
+
+        # Export to string
+        stream = io.StringIO()
+        doc.write(stream)
+        return stream.getvalue()
+
+    def _add_point_entity(self, msp, feature, p_layer, geom):
+        """Add a Point entity with associated text labels."""
+        if self.separate_layers:
+            layer_point = f"{p_layer}_POINTS"
+            layer_z_text = f"{p_layer}_Z_COORDS"
+            layer_id_text = f"{p_layer}_LABELS"
+        else:
+            layer_point = layer_z_text = layer_id_text = p_layer
+
+        x, y = float(geom.x), float(geom.y)
+
+        # Add point entity
+        try:
+            z = float(geom.z)
+            msp.add_point((x, y, z), dxfattribs={'layer': layer_point})
+        except (ValueError, AttributeError):
+            z = None
+            msp.add_point((x, y), dxfattribs={'layer': layer_point})
+
+        # Add ID text
+        msp.add_text(
+            str(feature.id),
+            dxfattribs={
+                'layer': layer_id_text,
+                'height': self.text_height,
+            }
+        ).set_placement((x, y), align=TextEntityAlignment.LEFT)
+
+        # Add Z value text (below the point)
+        if z is not None:
+            y_offset = y - (self.text_height * 1.2)
+            msp.add_text(
+                str(z),
+                dxfattribs={
+                    'layer': layer_z_text,
+                    'height': self.text_height,
+                }
+            ).set_placement((x, y_offset), align=TextEntityAlignment.LEFT)
+
+    def _add_linestring_entity(self, msp, feature, p_layer, geom):
+        """Add a LineString entity as a polyline."""
+        layer = p_layer if not self.separate_layers else p_layer
+
+        # Build list of vertices with 3D coordinates
+        vertices = []
+        for coord in geom.coords:
+            if len(coord) >= 3:
+                vertices.append((coord[0], coord[1], coord[2]))
+            else:
+                vertices.append((coord[0], coord[1], 0))
+
+        # Add 3D polyline
+        msp.add_polyline3d(
+            vertices,
+            dxfattribs={'layer': layer}
+        )

--- a/totalopenstation/tests/test_dxf.py
+++ b/totalopenstation/tests/test_dxf.py
@@ -3,7 +3,8 @@ import unittest
 from totalopenstation.formats import Feature, LineString, Point
 from totalopenstation.output.tops_dxf import OutputFormat
 
-class TestCSVOutput(unittest.TestCase):
+
+class TestDXFOutput(unittest.TestCase):
 
     def setUp(self):
         self.data = [
@@ -20,10 +21,63 @@ class TestCSVOutput(unittest.TestCase):
                     id=3),
         ]
 
-    def test_output(self):
-        self.output = OutputFormat(self.data, separate_layers=False).process()
-        self.assertEqual(self.output.splitlines()[1], 'DXF created from Total Open Station')
-        self.assertEqual(self.output.splitlines()[67], 'TESTPOINT')
-        self.assertEqual(self.output.splitlines()[103], 'TESTPOINT2')
-        self.assertEqual(self.output.splitlines()[139], 'TESTLINE')
-        self.assertEqual(self.output.splitlines()[183], 'EOF')
+    def test_output_is_valid_dxf(self):
+        """Test that output is a valid DXF string."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        # Check DXF structure markers
+        self.assertIn('SECTION', output)
+        self.assertIn('ENDSEC', output)
+        self.assertIn('EOF', output)
+
+    def test_output_contains_layers(self):
+        """Test that layers are created correctly."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        self.assertIn('TESTPOINT', output)
+        self.assertIn('TESTPOINT2', output)
+        self.assertIn('TESTLINE', output)
+
+    def test_output_separate_layers(self):
+        """Test that separate layers are created when enabled."""
+        output = OutputFormat(self.data, separate_layers=True).process()
+        self.assertIn('TESTPOINT_POINTS', output)
+        self.assertIn('TESTPOINT_LABELS', output)
+        self.assertIn('TESTPOINT_Z_COORDS', output)
+
+    def test_output_contains_points(self):
+        """Test that point entities are in the output."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        self.assertIn('POINT', output)
+
+    def test_output_contains_text(self):
+        """Test that text entities are in the output."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        self.assertIn('TEXT', output)
+
+    def test_output_contains_polyline(self):
+        """Test that polyline entities are in the output."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        self.assertIn('POLYLINE', output)
+
+    def test_output_contains_coordinates(self):
+        """Test that coordinates are in the output."""
+        output = OutputFormat(self.data, separate_layers=False).process()
+        # Check for coordinate values (as strings in DXF)
+        self.assertIn('12.8', output)
+        self.assertIn('76.3', output)
+        self.assertIn('56.2', output)
+
+    def test_can_be_parsed_by_ezdxf(self):
+        """Test that output can be parsed back by ezdxf."""
+        import io
+        import ezdxf
+
+        output = OutputFormat(self.data, separate_layers=False).process()
+        stream = io.StringIO(output)
+        doc = ezdxf.read(stream)
+
+        # Check that we have the expected entities
+        msp = doc.modelspace()
+        entities = list(msp)
+
+        # Should have: 2 points + 2 ID texts + 2 Z texts + 1 polyline = 7 entities
+        self.assertGreaterEqual(len(entities), 7)


### PR DESCRIPTION
## Summary
- Replace custom DXF writer with ezdxf library for robust DXF generation
- Add `ezdxf>=1.0.0` as dependency in pyproject.toml
- Maintain same functionality:
  - Point entities
  - Text entities (ID and Z coordinate labels)
  - Polyline entities (for LineString)
  - Separate layers option (points, labels, z_coords)
  - Layer colors based on point description
- Use R12 format for maximum compatibility with CAD software
- Updated tests to verify DXF structure and parseability by ezdxf

## Test plan
- [x] All 8 DXF tests pass
- [x] Output can be parsed back by ezdxf
- [x] Layers, points, text, and polylines are correctly generated

Fixes #127