### PR TITLE
Add Wild T1000 support

### DIFF
--- a/totalopenstation/models/__init__.py
+++ b/totalopenstation/models/__init__.py
@@ -115,5 +115,6 @@ BUILTIN_MODELS = {
     'leica_tcr_705': ('leica_tcr_705', 'ModelConnector', 'Leica TCR 705'),
     'trimble': ('trimble', 'ModelConnector', 'Trimble'), 
     'topcon_gpt_3005': ('topcon_gpt_3005', 'ModelConnector', 'Topcon GPT 3005'),
+    'wild_t1000': ('wild_t1000', 'ModelConnector', 'Wild T1000'),
     'custom': ('custom', 'CustomConnector', 'Custom/Unknown'),
     }

--- a/totalopenstation/models/wild_t1000.py
+++ b/totalopenstation/models/wild_t1000.py
@@ -1,0 +1,134 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# filename: wild_t1000.py
+# Copyright 2026 Carlo Pavan <carlopava@gmail.com>
+
+# This file is part of Total Open Station.
+
+# Total Open Station is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+
+# Total Open Station is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Total Open Station.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+
+from . import Connector
+
+PROCEED = b'?\r\n'
+
+
+def is_data_block(line):
+    '''True if a received line is a GSI block rather than protocol chatter.
+
+    GSI words start with a numeric word index (GSI-8) or ``*`` (GSI-16), while
+    the status line and any echo of our own request are short and do not.
+    '''
+
+    stripped = line.strip()
+    return len(stripped) > 4 and (stripped[:1].isdigit()
+                                  or stripped[:1] == b'*')
+
+
+def collect_wild_t1000_data(port, initial_timeout=60.0, record_timeout=5.0):
+    '''Download GSI records from a Wild T1000.
+
+    The instrument sends one record at a time and then waits. Each record is
+    two CRLF-terminated lines: the GSI data block, followed by a short status
+    line (observed as ``w``) which is not part of the data. The receiver asks
+    for the next record by sending ``?``. This mirrors the BASIC listing in
+    the instrument manual::
+
+        50 LINE INPUT #1,A$
+        60 LINE INPUT #1,B$
+        80 PRINT #2,A$
+        90 PRINT #1,"?"
+        100 GOTO 50
+
+    Handshaking is purely in-band: the manual's ``CS,DS,CD`` open options
+    disable waiting on the modem control lines, so no RTS/CTS or DSR/DTR
+    flow control is used.
+
+    What comes down the wire is sparser than a modern GSI file. The
+    instrument sends only the point number and the raw polar observation:
+
+        11 point number, 21 horizontal angle, 22 zenith angle,
+        31 slope distance, 32 horizontal distance, plus a leading 41 code
+        block
+
+    There is no station record and no reflector or instrument height, so
+    WI 84-88 and the computed coordinates 81-83 are all absent. The GSI
+    parser recognises this word index set as an old-style file and defaults
+    the missing values to zero (see issue #168), which means heights come out
+    relative to the line of sight and coordinates sit in a local frame
+    centred on the station. That is a limit of what the T1000 transmits, not
+    of the parsing: the missing values have to be supplied by hand afterwards.
+
+    Args:
+        port: an open serial-like object.
+        initial_timeout: seconds to wait for the first record, i.e. how long
+            the user has to start the transfer on the instrument.
+        record_timeout: seconds to wait for each subsequent record before
+            deciding the transfer has finished.
+
+    Returns:
+        bytes: the concatenated GSI data blocks, CRLF-terminated.
+    '''
+
+    records = []
+    previous_timeout = port.timeout
+
+    # Anything already buffered is stale: a leftover echo here would shift the
+    # data lines onto the status lines for the whole transfer.
+    port.reset_input_buffer()
+
+    try:
+        port.timeout = initial_timeout
+        while True:
+            line = port.readline()
+            if not line:
+                # Timed out: the instrument has nothing more to send.
+                break
+
+            if not is_data_block(line):
+                # Status line ("w"), echo of our own "?", or blank. Skip it
+                # rather than pairing lines positionally, so a stray byte
+                # cannot misalign the rest of the transfer.
+                continue
+
+            records.append(line)
+            port.write(PROCEED)
+            port.flush()
+            port.timeout = record_timeout
+
+    finally:
+        port.timeout = previous_timeout
+
+    return b''.join(records)
+
+
+class ModelConnector(Connector):
+
+    def __init__(self, port):
+        # Wild T1000 uses 2400 baud, 7 data bits, even parity, 2 stop bits
+        Connector.__init__(self, port=port, baudrate=2400, bytesize=7,
+                           parity='E', stopbits=2)
+
+    def download(self):
+        '''Download using the Wild T1000 request/response protocol.'''
+
+        self.result = collect_wild_t1000_data(self)
+
+    def fast_download(self):
+        # The T1000 transfer is driven by us, so there is nothing to wait for
+        # beyond the first record, which collect_wild_t1000_data handles.
+        self.dl_started.set()
+        self.download()
+        self.dl_finished.set()

--- a/totalopenstation/scripts/gui.py
+++ b/totalopenstation/scripts/gui.py
@@ -24,8 +24,6 @@ import serial
 import gettext
 import atexit
 
-from time import sleep
-
 from tkinter import *
 from tkinter.messagebox import showwarning, showinfo, askokcancel
 import tkinter.simpledialog
@@ -735,22 +733,18 @@ class Tops:
                     e = ErrorDialog(self.myParent, detail)
                 else:
                     st = DownloadDialog(self.myParent)
-                    sleeptime = float(self.option6_value.get())
                     if st.result:
                         self.status.set(_("Waiting for data: Please start the transfer from your total station menu."))
-                        while mc.inWaiting() == 0:
-                            sleep(sleeptime)
-                        n = mc.inWaiting()
-                        result = mc.read(n)
+                        # Honour the sleeptime currently shown in the GUI, not
+                        # the one stored in the preferences at startup.
+                        mc.sleeptime = float(self.option6_value.get())
+                        # Let the model drive the transfer: instruments such as
+                        # the Wild T1000 need a request sent for each record,
+                        # which a plain read loop cannot do.
+                        mc.fast_download()
+                        result = mc.result
+                        self.status.set(_('Downloaded %d bytes') % len(result))
                         self.replace_text(result.decode())
-                        sleep(sleeptime)
-
-                        while mc.inWaiting() > 0:
-                            newdata = mc.read(mc.inWaiting())
-                            result += newdata
-                            self.status.set(_('Downloaded %d bytes') % len(result))
-                            self.replace_text(result.decode())
-                            sleep(sleeptime) # TODO determine sleep time from baudrate
                         mc.close()
                         showinfo(_('Success!'),
                                  _('Download finished!\nYou have %d bytes of data.') % len(result))

--- a/totalopenstation/tests/test_wild_t1000.py
+++ b/totalopenstation/tests/test_wild_t1000.py
@@ -1,0 +1,113 @@
+import re
+import unittest
+
+from totalopenstation.formats.leica_gsi import FormatParser
+from totalopenstation.models.wild_t1000 import collect_wild_t1000_data
+
+# Recorded from a Wild T1000, so it carries only the word indexes the
+# instrument actually sends (11, 21, 22, 31, 32) — see issue #168.
+SAMPLE = 'sample_data/leica_gsi/RILIEVO.gsi'
+
+
+class FakeT1000:
+    '''A Wild T1000 replaying recorded GSI blocks.
+
+    It sends one record per '?' request, each being a data block followed by
+    a 'w' status line, and stops responding once the blocks run out.
+
+    Args:
+        blocks: the GSI data blocks to replay.
+        stale: bytes already buffered when the download starts.
+        echo: whether the link echoes our own request back at us.
+    '''
+
+    def __init__(self, blocks, stale=b'', echo=False):
+        self.blocks = list(blocks)
+        self.buf = bytearray(stale)
+        self.echo = echo
+        self.timeout = 1.0
+        self.started = False
+
+    def reset_input_buffer(self):
+        self.buf.clear()
+
+    def _emit(self):
+        if self.blocks:
+            self.buf.extend(self.blocks.pop(0) + b'\r\nw\r\n')
+
+    def readline(self):
+        if not self.started:
+            self.started = True
+            self._emit()
+        idx = self.buf.find(b'\n')
+        if idx == -1:
+            return b''
+        line, self.buf = bytes(self.buf[:idx + 1]), self.buf[idx + 1:]
+        return line
+
+    def write(self, data):
+        assert data == b'?\r\n'
+        if self.echo:
+            self.buf.extend(b'?\r\n')
+        self._emit()
+
+    def flush(self):
+        pass
+
+
+class TestWildT1000Connector(unittest.TestCase):
+
+    def setUp(self):
+        # Recorded files terminate blocks with CR, LF or both, so split on
+        # any run of them rather than assuming one flavour.
+        with open(SAMPLE, 'rb') as testdata:
+            lines = re.split(b'[\r\n]+', testdata.read())
+        self.blocks = [line for line in lines if line.strip()]
+
+    def download(self, **kwargs):
+        return collect_wild_t1000_data(FakeT1000(self.blocks, **kwargs))
+
+    def records(self, **kwargs):
+        data = self.download(**kwargs)
+        return [line for line in data.split(b'\r\n') if line.strip()]
+
+    def test_all_records(self):
+        self.assertEqual(self.records(), self.blocks)
+
+    def test_status_lines_are_not_data(self):
+        data = self.download()
+        # Assert we got something first: 'w' is absent from an empty
+        # download too, which would make this pass for the wrong reason.
+        self.assertTrue(data)
+        self.assertNotIn(b'w', data)
+
+    def test_stale_byte_does_not_shift_records(self):
+        # A leftover '?' used to shift every data line onto the discarded
+        # status line, yielding a download of nothing but 'w'.
+        self.assertEqual(self.records(stale=b'?\r\n'), self.blocks)
+
+    def test_echoed_request_is_ignored(self):
+        self.assertEqual(self.records(echo=True), self.blocks)
+
+    def test_noisy_start(self):
+        noise = b'\x00\r\nw\r\n?\r\n'
+        self.assertEqual(self.records(stale=noise), self.blocks)
+
+    def test_downloaded_data_is_parseable(self):
+        # The download is only useful if the GSI parser accepts it, so cover
+        # the seam between the two rather than each half alone. The expected
+        # values match TestLeicaGSIOldParser, which reads the same file from
+        # disk instead of over the wire.
+        fp = FormatParser(self.download().decode('ascii'))
+        self.assertEqual(len(fp.points), len(self.blocks))
+        point = fp.points[2]
+        self.assertEqual(point.id, 3)
+        self.assertEqual(point.desc, 'PT')
+        self.assertEqual(point.point_name, '102')
+        self.assertAlmostEqual(point.geometry.x, 4.49963916)
+        self.assertAlmostEqual(point.geometry.y, -2.51722711)
+        self.assertAlmostEqual(point.geometry.z, -0.30665937)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #167.

The code has been developed with Claude code, via manual testing and verification. The base script and the connection parameters are derived from the T1000 manual.

## The problem

The Wild T1000 sends one GSI record and then waits for the receiver to ask for the next one. A plain read loop only ever gets the first block, after
which the instrument aborts with `error 22` — which turns out to be the symptom of an unanswered request, not a transfer failure.

## The protocol

Each record is two CRLF-terminated lines: the GSI data block, followed by a short status line (`w`) that is not part of the data. The receiver requests
the next record by sending `?`. Handshaking is entirely in-band — the manual's `CS,DS,CD` open options disable waiting on the modem control lines,
so no RTS/CTS or DSR/DTR flow control is involved.

This comes from the BASIC listing in the instrument manual:

```basic
50 LINE INPUT #1,A$     ' the GSI data block
60 LINE INPUT #1,B$     ' the status line, discarded
80 PRINT #2,A$
90 PRINT #1,"?"         ' request the next record
100 GOTO 50
```

The manual also refers to the GIF2/GIF7 interfaces and to the GRE manual, which suggests other Wild instruments of the same generation use the same protocol — worth checking if anyone has one to hand.

Lines are classified rather than paired positionally. Pairing by position works only from a perfectly clean port: during testing a single leftover echoed `?` shifted every data line onto the discarded status line, producing a file containing nothing but `w`. Since the link echoes what we transmit, this was not a hypothetical.

## The GUI change

The GUI reimplemented the download loop inline, bypassing the models' `download()` method. That method exists precisely so an instrument can drive
its own transfer, but nothing could use it. Calling it removes 13 lines and means the T1000 needs no GUI changes at all — and neither will the next
instrument with a handshake of its own.

One caveat worth flagging: the inline loop updated the byte count as data arrived, and `download()` returns only when finished, so the status bar no
longer ticks during a transfer. On a T1000 at 2400 baud that is roughly twenty quiet seconds. Reporting progress would need a callback threaded
through `download()`, i.e. an API change across all models, so I left it out rather than decide it unilaterally — happy to add it if you'd prefer.

## Testing

Verified against a file downloaded from the same instrument with Meridiana: all 28 records recovered byte for byte, via the GUI on the real instrument.

`tests/test_wild_t1000.py` adds 6 tests that simulate the instrument, so they need no hardware. They cover the clean stream, the record/status split, an echoed request, and the stale-byte misalignment described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
